### PR TITLE
SONARCOVRG-14 handle overall coverage reports

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@
             <configuration>
               <rules>
                 <requireFilesSize>
-                  <maxsize>26000</maxsize>
+                  <maxsize>26500</maxsize>
                   <minsize>10000</minsize>
                   <files>
                     <file>${project.build.directory}/${project.build.finalName}.jar</file>

--- a/src/main/java/org/sonar/plugins/coverage/generic/CustomCoverageMeasuresBuilder.java
+++ b/src/main/java/org/sonar/plugins/coverage/generic/CustomCoverageMeasuresBuilder.java
@@ -22,16 +22,15 @@ package org.sonar.plugins.coverage.generic;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.SortedMap;
 import org.sonar.api.measures.CoreMetrics;
 import org.sonar.api.measures.Measure;
 import org.sonar.api.measures.Metric;
 import org.sonar.api.measures.PersistenceMode;
 import org.sonar.api.utils.KeyValueFormat;
-
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Map;
-import java.util.SortedMap;
 
 public final class CustomCoverageMeasuresBuilder {
 
@@ -56,6 +55,15 @@ public final class CustomCoverageMeasuresBuilder {
     .put(METRIC.UNCOVERED_CONDITIONS, CoreMetrics.IT_UNCOVERED_CONDITIONS)
     .put(METRIC.COVERED_CONDITIONS_BY_LINE, CoreMetrics.IT_COVERED_CONDITIONS_BY_LINE)
     .put(METRIC.CONDITIONS_BY_LINE, CoreMetrics.IT_CONDITIONS_BY_LINE).build();
+
+  private static final Map<METRIC, Metric> OVERALL_KEYS = ImmutableMap.<METRIC, Metric>builder()
+    .put(METRIC.LINES_TO_COVER, CoreMetrics.OVERALL_LINES_TO_COVER)
+    .put(METRIC.UNCOVERED_LINES, CoreMetrics.OVERALL_UNCOVERED_LINES)
+    .put(METRIC.COVERAGE_LINE_HITS_DATA, CoreMetrics.OVERALL_COVERAGE_LINE_HITS_DATA)
+    .put(METRIC.CONDITIONS_TO_COVER, CoreMetrics.OVERALL_CONDITIONS_TO_COVER)
+    .put(METRIC.UNCOVERED_CONDITIONS, CoreMetrics.OVERALL_UNCOVERED_CONDITIONS)
+    .put(METRIC.COVERED_CONDITIONS_BY_LINE, CoreMetrics.OVERALL_COVERED_CONDITIONS_BY_LINE)
+    .put(METRIC.CONDITIONS_BY_LINE, CoreMetrics.OVERALL_CONDITIONS_BY_LINE).build();
 
   private int totalCoveredLines = 0, totalConditions = 0, totalCoveredConditions = 0;
   private final SortedMap<Integer, Integer> hitsByLine = Maps.newTreeMap();
@@ -105,7 +113,6 @@ public final class CustomCoverageMeasuresBuilder {
     }
     return this;
   }
-
 
   public int getCoveredConditions() {
     return totalCoveredConditions;
@@ -163,6 +170,11 @@ public final class CustomCoverageMeasuresBuilder {
 
   public CustomCoverageMeasuresBuilder enableITMode() {
     metrics = IT_KEYS;
+    return this;
+  }
+
+  public CustomCoverageMeasuresBuilder enableOverallMode() {
+    metrics = OVERALL_KEYS;
     return this;
   }
 

--- a/src/main/java/org/sonar/plugins/coverage/generic/GenericCoveragePlugin.java
+++ b/src/main/java/org/sonar/plugins/coverage/generic/GenericCoveragePlugin.java
@@ -20,19 +20,19 @@
 package org.sonar.plugins.coverage.generic;
 
 import com.google.common.collect.ImmutableList;
+import java.util.List;
 import org.sonar.api.SonarPlugin;
 import org.sonar.api.config.PropertyDefinition;
 import org.sonar.api.resources.Qualifiers;
-
-import java.util.List;
 
 public class GenericCoveragePlugin extends SonarPlugin {
 
   private static final String CATEGORY = "Generic Coverage";
   public static final String OLD_REPORT_PATH_PROPERTY_KEY = "sonar.genericcoverage.reportPath";
-  public static final String REPORT_PATHS_PROPERTY_KEY = "sonar.genericcoverage.reportPaths";
-  public static final String IT_REPORT_PATHS_PROPERTY_KEY = "sonar.genericcoverage.itReportPaths";
+  public static final String COVERAGE_REPORT_PATHS_PROPERTY_KEY = "sonar.genericcoverage.reportPaths";
+  public static final String IT_COVERAGE_REPORT_PATHS_PROPERTY_KEY = "sonar.genericcoverage.itReportPaths";
   public static final String UNIT_TEST_REPORT_PATHS_PROPERTY_KEY = "sonar.genericcoverage.unitTestReportPaths";
+  public static final String OVERALL_COVERAGE_TEST_REPORT_PATHS_PROPERTY_KEY = "sonar.genericcoverage.overallTestReportPaths";
 
   @Override
   public List getExtensions() {
@@ -45,29 +45,36 @@ public class GenericCoveragePlugin extends SonarPlugin {
   private static ImmutableList<PropertyDefinition> pluginProperties() {
     return ImmutableList.of(
 
-      PropertyDefinition.builder(REPORT_PATHS_PROPERTY_KEY)
+      PropertyDefinition.builder(COVERAGE_REPORT_PATHS_PROPERTY_KEY)
         .name("Coverage report paths")
         .description("List of comma-separated paths (absolute or relative) containing coverage report.")
         .category(CATEGORY)
         .onQualifiers(Qualifiers.PROJECT)
         .build(),
 
-      PropertyDefinition.builder(IT_REPORT_PATHS_PROPERTY_KEY)
+      PropertyDefinition.builder(IT_COVERAGE_REPORT_PATHS_PROPERTY_KEY)
         .name("Integration tests coverage report paths")
         .description("List of comma-separated paths (absolute or relative) containing integration tests coverage report.")
         .category(CATEGORY)
         .onQualifiers(Qualifiers.PROJECT)
         .build(),
 
+      PropertyDefinition.builder(OVERALL_COVERAGE_TEST_REPORT_PATHS_PROPERTY_KEY)
+        .name("Overall tests coverage report paths")
+        .description("List of comma-separated paths (absolute or relative) containing overall tests coverage report.")
+        .category(CATEGORY)
+        .onQualifiers(Qualifiers.PROJECT)
+        .build(),
+
       PropertyDefinition.builder(UNIT_TEST_REPORT_PATHS_PROPERTY_KEY)
-        .name("Unit tests report paths")
-        .description("List of comma-separated paths (absolute or relative) containing unit tests report.")
+        .name("Unit tests results report paths")
+        .description("List of comma-separated paths (absolute or relative) containing unit tests results report.")
         .category(CATEGORY)
         .onQualifiers(Qualifiers.PROJECT)
         .build(),
 
       deprecatedPropertyDefinition(OLD_REPORT_PATH_PROPERTY_KEY)
-    );
+      );
   }
 
   private static PropertyDefinition deprecatedPropertyDefinition(String oldKey) {

--- a/src/main/java/org/sonar/plugins/coverage/generic/ReportParser.java
+++ b/src/main/java/org/sonar/plugins/coverage/generic/ReportParser.java
@@ -22,6 +22,14 @@ package org.sonar.plugins.coverage.generic;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import javax.xml.stream.XMLStreamException;
 import org.codehaus.staxmate.in.SMHierarchicCursor;
 import org.codehaus.staxmate.in.SMInputCursor;
 import org.sonar.api.batch.SensorContext;
@@ -33,24 +41,16 @@ import org.sonar.api.test.MutableTestPlan;
 import org.sonar.api.utils.SonarException;
 import org.sonar.api.utils.StaxParser;
 
-import javax.xml.stream.XMLStreamException;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.InputStream;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
 public class ReportParser {
 
   public enum Mode {
-    COVERAGE, IT_COVERAGE, UNITTEST
+    COVERAGE, IT_COVERAGE, OVERALL_COVERAGE, UNITTEST
   }
 
   private static final Map<Mode, String> ROOT_NODE = ImmutableMap.<Mode, String>builder()
     .put(Mode.COVERAGE, "coverage")
     .put(Mode.IT_COVERAGE, "coverage")
+    .put(Mode.OVERALL_COVERAGE, "coverage")
     .put(Mode.UNITTEST, "unitTest").build();
 
   private static final String LINE_NUMBER_ATTR = "lineNumber";
@@ -151,8 +151,15 @@ public class ReportParser {
     CustomCoverageMeasuresBuilder measuresBuilder = coverageMeasures.get(resource);
     if (measuresBuilder == null) {
       measuresBuilder = CustomCoverageMeasuresBuilder.create();
-      if (Mode.IT_COVERAGE == mode) {
-        measuresBuilder.enableITMode();
+      switch (mode) {
+        case IT_COVERAGE:
+          measuresBuilder.enableITMode();
+          break;
+        case OVERALL_COVERAGE:
+          measuresBuilder.enableOverallMode();
+          break;
+        default:
+          break;
       }
       coverageMeasures.put(resource, measuresBuilder);
     }

--- a/src/test/java/org/sonar/plugins/coverage/generic/GenericCoveragePluginTest.java
+++ b/src/test/java/org/sonar/plugins/coverage/generic/GenericCoveragePluginTest.java
@@ -27,7 +27,7 @@ public class GenericCoveragePluginTest {
 
   @Test
   public void extensions() throws Exception {
-    assertThat(new GenericCoveragePlugin().getExtensions()).hasSize(5);
+    assertThat(new GenericCoveragePlugin().getExtensions()).hasSize(6);
   }
 
 }

--- a/src/test/java/org/sonar/plugins/coverage/generic/GenericCoverageSensorTest.java
+++ b/src/test/java/org/sonar/plugins/coverage/generic/GenericCoverageSensorTest.java
@@ -21,6 +21,8 @@ package org.sonar.plugins.coverage.generic;
 
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
+import java.io.File;
+import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -33,9 +35,6 @@ import org.sonar.api.measures.Measure;
 import org.sonar.api.resources.Project;
 import org.sonar.api.resources.ProjectFileSystem;
 import org.sonar.api.utils.SonarException;
-
-import java.io.File;
-import java.util.List;
 
 import static org.fest.assertions.Assertions.assertThat;
 import static org.mockito.Matchers.any;
@@ -119,32 +118,37 @@ public class GenericCoverageSensorTest {
     assertThat(getLoggingEvents().get(1).getMessage()).contains("Parsing").contains("coverage.xml");
     assertThat(getLoggingEvents().get(2).getMessage()).contains("Imported coverage data for 1 file");
     assertThat(getLoggingEvents().get(4).getMessage()).contains("Imported IT coverage data for 0 files");
-    assertThat(getLoggingEvents().get(5).getMessage()).contains("Imported unit test data for 0 files");
+    assertThat(getLoggingEvents().get(5).getMessage()).contains("Imported Overall coverage data for 0 files");
+    assertThat(getLoggingEvents().get(6).getMessage()).contains("Imported unit test data for 0 files");
   }
 
   @Test
   public void analyse_report_with_relative_path() throws Exception {
     configureReportPaths("coverage.xml");
     configureITReportPaths("coverage.xml");
+    configureOverallReportPaths("coverage.xml");
     configureUTReportPaths("unittest.xml");
     org.sonar.api.resources.File resource = addFileToContext("src/test/resources/project1/src/foobar.js");
     org.sonar.api.resources.File testResource = addFileToContext("src/test/resources/project1/test/foobar_test.js");
     sensor.analyseWithLogger(project, context, logger);
-    verify(context, times(6)).saveMeasure(eq(resource), any(Measure.class));
+    verify(context, times(9)).saveMeasure(eq(resource), any(Measure.class));
     verify(context, times(6)).saveMeasure(eq(testResource), any(Measure.class));
 
     assertThat(getLoggingEvents().get(0).getMessage()).contains("Parsing").contains("coverage.xml");
     assertThat(getLoggingEvents().get(1).getMessage()).contains("Imported coverage data for 1 file");
     assertThat(getLoggingEvents().get(3).getMessage()).contains("Parsing ").contains("coverage.xml");
     assertThat(getLoggingEvents().get(4).getMessage()).contains("Imported IT coverage data for 1 file");
-    assertThat(getLoggingEvents().get(6).getMessage()).contains("Parsing ").contains("unittest.xml");
-    assertThat(getLoggingEvents().get(7).getMessage()).contains("Imported unit test data for 1 file");
+    assertThat(getLoggingEvents().get(6).getMessage()).contains("Parsing ").contains("coverage.xml");
+    assertThat(getLoggingEvents().get(7).getMessage()).contains("Imported Overall coverage data for 1 file");
+    assertThat(getLoggingEvents().get(9).getMessage()).contains("Parsing ").contains("unittest.xml");
+    assertThat(getLoggingEvents().get(10).getMessage()).contains("Imported unit test data for 1 file");
   }
 
   @Test
   public void analyse_report_with_multiple_relative_path() throws Exception {
     configureReportPaths("coverage.xml,coverage2.xml");
     configureITReportPaths("coverage.xml,coverage2.xml");
+    configureOverallReportPaths("coverage.xml,coverage2.xml");
     configureUTReportPaths("unittest.xml,unittest2.xml");
     org.sonar.api.resources.File resource1 = addFileToContext("src/test/resources/project1/src/foobar.js");
     org.sonar.api.resources.File resource2 = addFileToContext("src/test/resources/project1/src/helloworld.js");
@@ -152,9 +156,9 @@ public class GenericCoverageSensorTest {
     org.sonar.api.resources.File testResource1 = addFileToContext("src/test/resources/project1/test/foobar_test.js");
     org.sonar.api.resources.File testResource2 = addFileToContext("src/test/resources/project1/test/helloworld_test.js");
     sensor.analyseWithLogger(project, context, logger);
-    verify(context, times(6)).saveMeasure(eq(resource1), any(Measure.class));
-    verify(context, times(6)).saveMeasure(eq(resource2), any(Measure.class));
-    verify(context, times(6)).saveMeasure(eq(resource3), any(Measure.class));
+    verify(context, times(9)).saveMeasure(eq(resource1), any(Measure.class));
+    verify(context, times(9)).saveMeasure(eq(resource2), any(Measure.class));
+    verify(context, times(9)).saveMeasure(eq(resource3), any(Measure.class));
     verify(context, times(6)).saveMeasure(eq(testResource1), any(Measure.class));
     verify(context, times(6)).saveMeasure(eq(testResource2), any(Measure.class));
 
@@ -164,9 +168,12 @@ public class GenericCoverageSensorTest {
     assertThat(getLoggingEvents().get(3).getMessage()).contains("Parsing").contains("coverage.xml");
     assertThat(getLoggingEvents().get(4).getMessage()).contains("Parsing").contains("coverage2.xml");
     assertThat(getLoggingEvents().get(5).getMessage()).isEqualTo("Imported IT coverage data for 3 files");
-    assertThat(getLoggingEvents().get(6).getMessage()).contains("Parsing").contains("unittest.xml");
-    assertThat(getLoggingEvents().get(7).getMessage()).contains("Parsing").contains("unittest2.xml");
-    assertThat(getLoggingEvents().get(8).getMessage()).isEqualTo("Imported unit test data for 2 files");
+    assertThat(getLoggingEvents().get(6).getMessage()).contains("Parsing").contains("coverage.xml");
+    assertThat(getLoggingEvents().get(7).getMessage()).contains("Parsing").contains("coverage2.xml");
+    assertThat(getLoggingEvents().get(8).getMessage()).isEqualTo("Imported Overall coverage data for 3 files");
+    assertThat(getLoggingEvents().get(9).getMessage()).contains("Parsing").contains("unittest.xml");
+    assertThat(getLoggingEvents().get(10).getMessage()).contains("Parsing").contains("unittest2.xml");
+    assertThat(getLoggingEvents().get(11).getMessage()).isEqualTo("Imported unit test data for 2 files");
   }
 
   @Test
@@ -182,14 +189,15 @@ public class GenericCoverageSensorTest {
   public void analyse_report_with_multiple_absolute_path() throws Exception {
     configureReportPaths(new File(baseDir, "coverage.xml").getAbsolutePath() + "," + new File(baseDir, "coverage2.xml").getAbsolutePath());
     configureITReportPaths(new File(baseDir, "coverage.xml").getAbsolutePath() + "," + new File(baseDir, "coverage2.xml").getAbsolutePath());
+    configureOverallReportPaths(new File(baseDir, "coverage.xml").getAbsolutePath() + "," + new File(baseDir, "coverage2.xml").getAbsolutePath());
     configureUTReportPaths(new File(baseDir, "unittest.xml").getAbsolutePath() + "," + new File(baseDir, "unittest2.xml").getAbsolutePath());
     org.sonar.api.resources.File resource = addFileToContext("src/test/resources/project1/src/foobar.js");
     org.sonar.api.resources.File resource2 = addFileToContext("src/test/resources/project1/src/helloworld.js");
     org.sonar.api.resources.File testResource = addFileToContext("src/test/resources/project1/test/foobar_test.js");
     org.sonar.api.resources.File testResource2 = addFileToContext("src/test/resources/project1/test/helloworld_test.js");
     sensor.analyseWithLogger(project, context, logger);
-    verify(context, times(6)).saveMeasure(eq(resource), any(Measure.class));
-    verify(context, times(6)).saveMeasure(eq(resource2), any(Measure.class));
+    verify(context, times(9)).saveMeasure(eq(resource), any(Measure.class));
+    verify(context, times(9)).saveMeasure(eq(resource2), any(Measure.class));
     verify(context, times(6)).saveMeasure(eq(testResource), any(Measure.class));
     verify(context, times(6)).saveMeasure(eq(testResource2), any(Measure.class));
 
@@ -199,26 +207,32 @@ public class GenericCoverageSensorTest {
     assertThat(getLoggingEvents().get(4).getMessage()).contains("Parsing").contains("coverage.xml");
     assertThat(getLoggingEvents().get(5).getMessage()).contains("Parsing").contains("coverage2.xml");
     assertThat(getLoggingEvents().get(6).getMessage()).contains("Imported IT coverage data for 2 file");
-    assertThat(getLoggingEvents().get(8).getMessage()).contains("Parsing").contains("unittest.xml");
-    assertThat(getLoggingEvents().get(9).getMessage()).contains("Parsing").contains("unittest2.xml");
-    assertThat(getLoggingEvents().get(10).getMessage()).contains("Imported unit test data for 2 file");
+    assertThat(getLoggingEvents().get(8).getMessage()).contains("Parsing").contains("coverage.xml");
+    assertThat(getLoggingEvents().get(9).getMessage()).contains("Parsing").contains("coverage2.xml");
+    assertThat(getLoggingEvents().get(10).getMessage()).contains("Imported Overall coverage data for 2 file");
+    assertThat(getLoggingEvents().get(12).getMessage()).contains("Parsing").contains("unittest.xml");
+    assertThat(getLoggingEvents().get(13).getMessage()).contains("Parsing").contains("unittest2.xml");
+    assertThat(getLoggingEvents().get(14).getMessage()).contains("Imported unit test data for 2 file");
   }
 
   @Test
   public void analyse_report_with_unknown_files() throws Exception {
     configureReportPaths("coverage_with_2_unknown_files.xml");
     configureITReportPaths("coverage_with_2_unknown_files.xml");
+    configureOverallReportPaths("coverage_with_2_unknown_files.xml");
     configureUTReportPaths("unittest_with_2_unknown_files.xml");
     sensor.analyseWithLogger(project, context, logger);
     assertThat(getLoggingEvents().get(2).getMessage()).contains("coverage data ignored for 2 unknown files");
     assertThat(getLoggingEvents().get(5).getMessage()).contains("IT coverage data ignored for 2 unknown files");
-    assertThat(getLoggingEvents().get(8).getMessage()).contains("unit test data ignored for 2 unknown files");
+    assertThat(getLoggingEvents().get(8).getMessage()).contains("Overall coverage data ignored for 2 unknown files");
+    assertThat(getLoggingEvents().get(11).getMessage()).contains("unit test data ignored for 2 unknown files");
   }
 
   @Test
   public void analyse_report_with_7_unknown_files() throws Exception {
     configureReportPaths("coverage_with_7_unknown_files.xml");
     configureITReportPaths("coverage_with_7_unknown_files.xml");
+    configureOverallReportPaths("coverage_with_7_unknown_files.xml");
     configureUTReportPaths("unittest_with_7_unknown_files.xml");
     sensor.analyseWithLogger(project, context, logger);
     String message = getLoggingEvents().get(2).getMessage();
@@ -230,6 +244,10 @@ public class GenericCoverageSensorTest {
     assertThat(message).contains("unknown1.js");
     assertThat(Splitter.on("\n").split(message)).hasSize(6);
     message = getLoggingEvents().get(8).getMessage();
+    assertThat(message).contains("Overall coverage data ignored for 7 unknown files");
+    assertThat(message).contains("unknown1.js");
+    assertThat(Splitter.on("\n").split(message)).hasSize(6);
+    message = getLoggingEvents().get(11).getMessage();
     assertThat(message).contains("unit test data ignored for 7 unknown files");
     assertThat(message).contains("unknown1.js");
     assertThat(Splitter.on("\n").split(message)).hasSize(6);
@@ -238,23 +256,33 @@ public class GenericCoverageSensorTest {
   @Test
   public void analyse_report_not_found() throws Exception {
     configureReportPaths("xxx");
+    configureITReportPaths("");
+    configureOverallReportPaths("");
     sensor.analyseWithLogger(project, context, logger);
     verifyZeroInteractions(context);
     assertThat(getLoggingEvents().get(1).getLevel()).isEqualTo("warn");
     assertThat(getLoggingEvents().get(1).getMessage()).contains("Cannot find coverage");
     configureReportPaths("");
     configureITReportPaths("xxx");
+    configureOverallReportPaths("");
     sensor.analyseWithLogger(project, context, logger);
     verifyZeroInteractions(context);
     assertThat(getLoggingEvents().get(4).getLevel()).isEqualTo("warn");
     assertThat(getLoggingEvents().get(4).getMessage()).contains("Cannot find IT coverage");
     configureReportPaths("");
     configureITReportPaths("");
-    configureUTReportPaths("xxx");
+    configureOverallReportPaths("xxx");
     sensor.analyseWithLogger(project, context, logger);
     verifyZeroInteractions(context);
     assertThat(getLoggingEvents().get(8).getLevel()).isEqualTo("warn");
-    assertThat(getLoggingEvents().get(8).getMessage()).contains("Cannot find unit test");
+    assertThat(getLoggingEvents().get(8).getMessage()).contains("Cannot find Overall coverage");
+    configureReportPaths("");
+    configureOverallReportPaths("");
+    configureUTReportPaths("xxx");
+    sensor.analyseWithLogger(project, context, logger);
+    verifyZeroInteractions(context);
+    assertThat(getLoggingEvents().get(13).getMessage()).contains("Cannot find unit test");
+    assertThat(getLoggingEvents().get(13).getLevel()).isEqualTo("warn");
   }
 
   @Test(expected = SonarException.class)
@@ -266,6 +294,12 @@ public class GenericCoverageSensorTest {
   @Test(expected = SonarException.class)
   public void it_analyse_txt_report() throws Exception {
     configureITReportPaths("not-xml.txt");
+    sensor.analyse(project, context);
+  }
+
+  @Test(expected = SonarException.class)
+  public void overall_analyse_txt_report() throws Exception {
+    configureOverallReportPaths("not-xml.txt");
     sensor.analyse(project, context);
   }
 
@@ -288,6 +322,12 @@ public class GenericCoverageSensorTest {
   }
 
   @Test(expected = SonarException.class)
+  public void overall_analyse_invalid_report() throws Exception {
+    configureOverallReportPaths("invalid-coverage.xml");
+    sensor.analyse(project, context);
+  }
+
+  @Test(expected = SonarException.class)
   public void ut_analyse_invalid_report() throws Exception {
     configureUTReportPaths("invalid-unittest.xml");
     sensor.analyse(project, context);
@@ -303,11 +343,15 @@ public class GenericCoverageSensorTest {
   }
 
   private void configureReportPaths(String reportPaths) {
-    when(settings.getString(GenericCoveragePlugin.REPORT_PATHS_PROPERTY_KEY)).thenReturn(reportPaths);
+    when(settings.getString(GenericCoveragePlugin.COVERAGE_REPORT_PATHS_PROPERTY_KEY)).thenReturn(reportPaths);
   }
 
   private void configureITReportPaths(String itReportPaths) {
-    when(settings.getString(GenericCoveragePlugin.IT_REPORT_PATHS_PROPERTY_KEY)).thenReturn(itReportPaths);
+    when(settings.getString(GenericCoveragePlugin.IT_COVERAGE_REPORT_PATHS_PROPERTY_KEY)).thenReturn(itReportPaths);
+  }
+
+  private void configureOverallReportPaths(String overallReportPaths) {
+    when(settings.getString(GenericCoveragePlugin.OVERALL_COVERAGE_TEST_REPORT_PATHS_PROPERTY_KEY)).thenReturn(overallReportPaths);
   }
 
   private void configureUTReportPaths(String utReportPaths) {


### PR DESCRIPTION
The plugin now reports correctly overall coverage. Here is a list of
what has been done.

- modified plugin classes to handle overall coverage report
- fixed tests to make them pass
- modified pom.xml in order to increase jar max size

Existing tests are really difficult to read and understand as they are
based on logger messages. I let you check what has been done + what
test is missing if any.